### PR TITLE
test pour résoudre les problèmes de validation travis sur les fichiers de texte

### DIFF
--- a/data/crnl026799472/crnl025/crnl026799472.crnl025.obvilchartes25-1.xml
+++ b/data/crnl026799472/crnl025/crnl026799472.crnl025.obvilchartes25-1.xml
@@ -51,13 +51,13 @@
         <cRefPattern 
           n="level1"
           matchPattern="(\w+)"
-          replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div//tei:l[@n='$1'])">
+          replacementPattern="#xpath(/TEI/text/body//l[@n='$1'])">
           <p>level1 récupère les vers</p>
         </cRefPattern>
       </refsDecl>
     </encodingDesc>
   </teiHeader>
-  <text xml:base="urn:cts:freLit:crnl026799472.crnl025.obvilchartes25-1">
+  <text xml:base="urn:cts:freLit:crnl026799472.crnl025.obvilchartes25-1" xml:lang="fr">
     <front>
       <titlePage>
         <docTitle>


### PR DESCRIPTION
Ceci est un test pour résoudre les problèmes de validation des documents xml contenant les textes. Il peut s'agir d'un problème d'XPATH lié au fait que les fichiers ne sont pas de la TEI valide