### PR TITLE
retrait balise en trop

### DIFF
--- a/data/crnl026799472/crnl007/crnl026799472.crnl007.obvilchartes7-2.xml
+++ b/data/crnl026799472/crnl007/crnl026799472.crnl007.obvilchartes7-2.xml
@@ -46,7 +46,6 @@
         </keywords>
       </textClass>
     </profileDesc>
-</profileDesc>
 <encodingDesc>
       <refsDecl n="CTS">
         <cRefPattern 


### PR DESCRIPTION
@LucenceIng a trouvé un '\</profileDesc\>' en trop, issu d'un mauvais copié-collé. Espérons que ça règle tous nos problèmes !